### PR TITLE
Fix date small screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -108,6 +108,7 @@ h1 > a:hover {
 .post-date {
    font-weight: normal;
    color: #666666;
+   display: inline-block;
 }
 
 /* PAGES */


### PR DESCRIPTION
On small screens, the post date in broken in two lines, I've just made a small fix for this

**Before -> After**
![change2](https://cloud.githubusercontent.com/assets/9850526/12372780/2f323bb6-bc63-11e5-9358-22c00d632afe.png)
