### PR TITLE
[32] NSTask/Process/CommandLine renaming

### DIFF
--- a/_drafts/2016-07-28-issue-32.md
+++ b/_drafts/2016-07-28-issue-32.md
@@ -24,6 +24,20 @@ Welcome to issue #32!
 func runAndExit() -> Never { /* ... */ }
 {% endhighlight %}
 
+As part of [SE-0086](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md), `Process` has been [renamed](https://github.com/apple/swift/pull/3598) to `CommandLine`, and `NSTask` has been [renamed](https://github.com/apple/swift/pull/3670) to `Process`:
+
+{% highlight swift %}
+// Old
+let task = NSTask()
+task.launchPath = "/usr/bin/echo"
+task.arguments = Process.arguments
+
+// New
+let process = Process()
+process.launchPath = "/usr/bin/echo"
+process.arguments = CommandLine.arguments
+{% endhighlight %}
+
 > TODO
 
 ### Accepted proposals


### PR DESCRIPTION
Two renamings:

1. Process -> CommandLine
2. NSTask -> Process

Pretty confusing, so I included an example. Hopefully that makes it a little easier to follow...