### PR TITLE
Add the news about naming change of NSOutputStream

### DIFF
--- a/_drafts/2016-07-28-issue-32.md
+++ b/_drafts/2016-07-28-issue-32.md
@@ -41,6 +41,8 @@ process.launchPath = "/usr/bin/echo"
 process.arguments = CommandLine.arguments
 {% endhighlight %}
 
+Also as a part of [SE-0086](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md), `OutputStream` was [renamed](https://github.com/apple/swift/pull/3576) to `TextOutputStream` and `NSOutputStream` was [renamed](https://github.com/apple/swift/pull/3667) to `OutputStream`.
+
 Ayaka Nonaka [merged](https://github.com/apple/swift/pull/3745) changes to import Objective-C's `@compatibility_alias` compiler directive as a Swift `typealias`.
 
 [SE-0131](https://github.com/apple/swift-evolution/blob/master/proposals/0131-anyhashable.md) was [implemented](https://github.com/apple/swift/pull/3554) by Dmitri Gribenko. This adds a type-erased `AnyHashable` container to the standard library.


### PR DESCRIPTION
Also as a part of [SE-0086](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md), `OutputStream` was [renamed](https://github.com/apple/swift/pull/3576) to `TextOutputStream` and `NSOutputStream` was [renamed](https://github.com/apple/swift/pull/3667) to `OutputStream`

I have also sent a pull request to [swift-evolution](https://github.com/apple/swift-evolution/pull/472) to reflect the actual naming change.

Thanks!