### PR TITLE
Fix the link to `ccs-twistedextensions`

### DIFF
--- a/_drafts/2016-08-25-issue-35.md
+++ b/_drafts/2016-08-25-issue-35.md
@@ -23,7 +23,7 @@ This project isn't particularly relevant to the Swift community, although it is 
 Calendar and Contacts Server repositories:
 
 - [ccs-calendarserver](https://github.com/apple/ccs-calendarserver)
-- [ccs-twistedextensions](]https://github.com/apple/ccs-twistedextensions)
+- [ccs-twistedextensions](https://github.com/apple/ccs-twistedextensions)
 - [ccs-pysecuretransport](https://github.com/apple/ccs-pysecuretransport)
 - [ccs-pyosxframeworks](https://github.com/apple/ccs-pyosxframeworks)
 - [ccs-pycalendar](https://github.com/apple/ccs-pycalendar)


### PR DESCRIPTION
The extra `]` prevented it from becoming a link.