### PR TITLE
Add "TODO" and Apple projects to ignored Proselint words

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -2,7 +2,7 @@
 prose.lint_files
 
 # Look for spelling issues
-prose.ignored_words = ["Swift", "iOS", "macOS", "watchOS", "tvOS", "iPhone", "iPad", "nonnull", "nullable", "nullability", "corelibs-foundation", "corelibs-libdispatch", "stdlib", "GCD", "SwiftPM", "Xcode", "TODO", "swift-evolution", "swift-package-manager", "swift-lldb", "swift-clang", "swift-llvm"]
+prose.ignored_words = ["Swift", "iOS", "macOS", "watchOS", "tvOS", "iPhone", "iPad", "nonnull", "nullable", "nullability", "corelibs-foundation", "corelibs-libdispatch", "stdlib", "GCD", "SwiftPM", "Xcode", "TODO", "swift-evolution", "swift-package-manager", "swift-lldb", "swift-clang", "swift-llvm", "swift-corelibs-foundation", "swift-corelibs-libdispatch"]
 prose.check_spelling
 
 # Ensure a clean commits history

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,7 +2,7 @@
 prose.lint_files
 
 # Look for spelling issues
-prose.ignored_words = ["Swift", "iOS", "macOS", "watchOS", "tvOS", "iPhone", "iPad", "nonnull", "nullable", "nullability", "corelibs-foundation", "corelibs-libdispatch", "stdlib", "GCD", "SwiftPM", "Xcode"]
+prose.ignored_words = ["Swift", "iOS", "macOS", "watchOS", "tvOS", "iPhone", "iPad", "nonnull", "nullable", "nullability", "corelibs-foundation", "corelibs-libdispatch", "stdlib", "GCD", "SwiftPM", "Xcode", "TODO", "swift-evolution", "swift-package-manager", "swift-lldb", "swift-clang", "swift-llvm"]
 prose.check_spelling
 
 # Ensure a clean commits history


### PR DESCRIPTION
As suggested [here](https://github.com/SwiftWeekly/swiftweekly.github.io/pull/77#issuecomment-245959295). 