### PR TITLE
[45] Add SE-0145 in review

### DIFF
--- a/_drafts/2016-11-03-issue-45.md
+++ b/_drafts/2016-11-03-issue-45.md
@@ -26,9 +26,9 @@ Brian Gesiak got [Swift building on CentOS](https://twitter.com/modocache/status
 
 > TODO
 
-### Proposals
+### Proposals in review
 
-No proposal [status](http://apple.github.io/swift-evolution/) updates this week!
+Proposal [SE-0145](https://github.com/apple/swift-evolution/blob/master/proposals/0145-package-manager-version-pinning.md): *Package Manager Version Pinning* from Daniel Dunbar, Ankit Aggarwal & Graydon Hoare is [under review](https://github.com/apple/swift-evolution/commit/91725ee83fa34c81942a634dcdfa9d2441fbd853).
 
 ### Mailing lists
 

--- a/_drafts/2016-11-03-issue-45.md
+++ b/_drafts/2016-11-03-issue-45.md
@@ -28,7 +28,7 @@ Brian Gesiak got [Swift building on CentOS](https://twitter.com/modocache/status
 
 ### Proposals in review
 
-Proposal [SE-0145](https://github.com/apple/swift-evolution/blob/master/proposals/0145-package-manager-version-pinning.md): *Package Manager Version Pinning* from Daniel Dunbar, Ankit Aggarwal & Graydon Hoare is [under review](https://github.com/apple/swift-evolution/commit/91725ee83fa34c81942a634dcdfa9d2441fbd853).
+Proposal [SE-0145](https://github.com/apple/swift-evolution/blob/master/proposals/0145-package-manager-version-pinning.md): *Package Manager Version Pinning* from Daniel Dunbar, Ankit Aggarwal & Graydon Hoare is [under review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20161031/028579.html).
 
 ### Mailing lists
 


### PR DESCRIPTION
The *under review*-url now links to the commit, as there has not been a mail to announce the review.