### PR TITLE
Fix a typo (void -> Void)

### DIFF
--- a/_drafts/2017-01-05-issue-51.md
+++ b/_drafts/2017-01-05-issue-51.md
@@ -10,7 +10,7 @@ Welcome back to the weekly! Hopefully you enjoyed some time off over the last fe
 
 ### Starter tasks
 
-- [SR-3359](https://bugs.swift.org/browse/SR-3359): [Compiler] Warn if `@discardableResult` is used with a `void` result.
+- [SR-3359](https://bugs.swift.org/browse/SR-3359): [Compiler] Warn if `@discardableResult` is used with a `Void` result.
 - [SR-3281](https://bugs.swift.org/browse/SR-3281): [Compiler] The Swift man page is out of date
 - [SR-3207](https://bugs.swift.org/browse/SR-3207): [Compiler] Segmentation fault with Objective-C parameter of `NSError* __autoreleasing __nonnull * __nullable`
 


### PR DESCRIPTION
Although the SR-title is talking about `void`, I think `Void` is a little clearer, as that's how it is used normally. :)