### PR TITLE
Add list of authors

### DIFF
--- a/authors.html
+++ b/authors.html
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Authors
+permalink: /authors/
+---
+<h1 class="center">List of authors</h1>
+{% for author in site.data.authors %}
+  {% assign posts = site.posts | where: "author", author[0] %}
+  <h2 class="lead post-title"><a href="https://twitter.com/{{ author[1].twitter }}"><em>{{ author[1].name }}</em></a> <small>{{ posts.size }} post{% if posts.size > 1 %}s{% endif %}</small></h2>
+  <p>{{ author[1].bio }}</p>
+  <ul class="posts-list">
+    {% for post in posts %}
+    <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+    {% endfor %}
+  </ul>
+{% endfor %}

--- a/authors.html
+++ b/authors.html
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: Authors
-permalink: /authors/
 ---
-<h1 class="center">List of authors</h1>
+
+<h1 class="text-center">{{ page.title }}</h1>
 {% for author in site.data.authors %}
   {% assign posts = site.posts | where: "author", author[0] %}
   <h2 class="lead post-title"><a href="https://twitter.com/{{ author[1].twitter }}"><em>{{ author[1].name }}</em></a> <small>{{ posts.size }} post{% if posts.size > 1 %}s{% endif %}</small></h2>

--- a/css/style.css
+++ b/css/style.css
@@ -159,3 +159,10 @@ blockquote {
    display: inline-block;
    padding: 0.5rem;
 }
+
+/* AUTHORS */
+
+.posts-list li {
+  min-width: 70px;
+  display: inline-block;
+}


### PR DESCRIPTION
Here is a proposal for #155. It implement a list of authors with the list of each contribution. The page is accessible under https://swiftweekly.github.io/authors/ but isn't referenced anywhere for now.

This commit does not add the bios referenced in the code. _Example using twitter bios:_

---
![](https://cloud.githubusercontent.com/assets/9850526/22303421/88376004-e333-11e6-800e-4ee9ff09011a.png)
