### PR TITLE
Add avatars to authors page

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,12 +1,16 @@
 jsq:
     name: 'Jesse Squires'
     twitter: jesse_squires
+    github: jessesquires
 modocache:
     name: 'Brian Gesiak'
     twitter: modocache
+    github: modocache
 jpsim:
     name: 'JP Simard'
     twitter: simjp
+    github: jpsim
 btb:
     name: 'Bas Broek'
     twitter: basthomas
+    github: BasThomas

--- a/authors.html
+++ b/authors.html
@@ -7,6 +7,7 @@ title: Authors
 <br />
 {% for author in site.data.authors %}
     {% assign posts = site.posts | where: "author", author[0] %}
+    <img class ="img-circle" src="https://github.com/{{ author[1].github }}.png?size=80" />
     <p class="lead"><a href="https://twitter.com/{{ author[1].twitter }}">{{ author[1].name }}</a>
         <span class="post-count text-muted">{{ posts.size }} post{% if posts.size > 1 %}s{% endif %}</span>
     </p>

--- a/authors.html
+++ b/authors.html
@@ -7,7 +7,7 @@ title: Authors
 <br />
 {% for author in site.data.authors %}
     {% assign posts = site.posts | where: "author", author[0] %}
-    <img class ="img-circle" src="https://github.com/{{ author[1].github }}.png?size=80" />
+    <img class="img-circle" src="https://github.com/{{ author[1].github }}.png?size=80" />
     <p class="lead"><a href="https://twitter.com/{{ author[1].twitter }}">{{ author[1].name }}</a>
         <span class="post-count text-muted">{{ posts.size }} post{% if posts.size > 1 %}s{% endif %}</span>
     </p>


### PR DESCRIPTION
Ref #175 
Using the GitHub avatars right now.

<img width="1067" alt="screen shot 2017-01-30 at 21 52 26" src="https://cloud.githubusercontent.com/assets/4190298/22441134/70a278a0-e736-11e6-8338-717cabb3ef15.png">