### PR TITLE
[62] SE-0157 accepted

### DIFF
--- a/_drafts/2017-03-23-issue-62.md
+++ b/_drafts/2017-03-23-issue-62.md
@@ -34,6 +34,16 @@ sponsor:
 
 ### Accepted proposals
 
+[SE-0156](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md): *Class and Subtype existentials* was [accepted](https://lists.swift.org/pipermail/swift-evolution-announce/2017-March/000331.html).
+
+> The review of SE-0156 "Class and Subtype Existentials" ran from February 28...March 7, 2017. The proposal was very well-received and is accepted with one modification: the ordering rules for existential types that involve `AnyObject` or a `class` type will be removed.
+>
+> The ordering rules were intended to improve code clarity by requiring that the `class` (or `AnyObject`) constraint come first - `AnyObject & P` would be well-formed but `P & AnyObject` would be an error—enforcing more uniformity for Swift code and echoing a similar restriction that already exists for class definitions, where the superclass must come first. However, the ability to compose typealiases complicated the ordering rules considerably, and - [as noted](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170227/033365.html) by Matthew Johnson - don’t provide the guarantee that the class constraint will always be first. Therefore, the core team felt that the resulting ordering rules introduced more complexity than they provided clarity, and therefore do not belong in the language.
+
+[SE-0157](https://github.com/apple/swift-evolution/blob/master/proposals/0157-recursive-protocol-constraints.md): *Support recursive constraints on associated types* was [accepted](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170320/034266.html).
+
+> The review of "SE-0157: Support recursive constraints on associated types" ran from Feburary 28th through March 8th, 2017.  The feedback on the proposal was unfailingly positive. Accordingly, the proposal has been accepted without further modification.
+
 [SE-0158](https://github.com/apple/swift-evolution/blob/master/proposals/0158-package-manager-manifest-api-redesign.md): *Package Manager Manifest API Redesign* was [accepted](https://lists.swift.org/pipermail/swift-evolution-announce/2017-March/000330.html) for Swift 4.
 
 > The review of SE-0158 "Package Manager Manifest API Redesign" ran from March 7 until March 15. The proposal is accepted with the following revisions:
@@ -47,12 +57,6 @@ sponsor:
 > – We will have cases for `.branch` and `.revision` version specifiers, but will not provide special package initializers with named parameters for these.
 >
 > This proposal was generally supported, though it did require some discussion and minor revision, and some users are eager for future proposals adding new API not covered by this proposal.
-
-[SE-0156](https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md): *Class and Subtype existentials* was [accepted](https://lists.swift.org/pipermail/swift-evolution-announce/2017-March/000331.html).
-
-> The review of SE-0156 "Class and Subtype Existentials" ran from February 28...March 7, 2017. The proposal was very well-received and is accepted with one modification: the ordering rules for existential types that involve `AnyObject` or a `class` type will be removed.
->
-> The ordering rules were intended to improve code clarity by requiring that the `class` (or `AnyObject`) constraint come first - `AnyObject & P` would be well-formed but `P & AnyObject` would be an error—enforcing more uniformity for Swift code and echoing a similar restriction that already exists for class definitions, where the superclass must come first. However, the ability to compose typealiases complicated the ordering rules considerably, and - [as noted](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170227/033365.html) by Matthew Johnson - don’t provide the guarantee that the class constraint will always be first. Therefore, the core team felt that the resulting ordering rules introduced more complexity than they provided clarity, and therefore do not belong in the language.
 
 ### Returned proposals
 


### PR DESCRIPTION
Also changed the order, so SE-0156 precedes SE-0157 precedes SE-0158. :)