### PR TITLE
[64] SE-0161 returned, SE-0163 and SE-0164 in review

### DIFF
--- a/_drafts/2017-04-06-issue-64.md
+++ b/_drafts/2017-04-06-issue-64.md
@@ -30,6 +30,43 @@ Speaking of JP Simard, he released [SourceKitten 0.17.1](https://github.com/jpsi
 
 > TODO
 
+### Returned proposals
+
+[SE-0161](https://github.com/apple/swift-evolution/blob/master/proposals/0161-key-paths.md): *Smart KeyPaths: Better Key-Value Coding for Swift* by David Smith, Michael LeHew, and Joe Groff was [under review](https://lists.swift.org/pipermail/swift-evolution-announce/2017-March/000334.html) and has now been returned for [a second round](https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000342.html).
+
+> We propose a family of concrete _Key Path_ types that represent uninvoked references to properties that can be composed to form paths through many values and directly get/set their underlying values.
+>
+> **We Can Do Better than String**<br/>
+> On Darwin platforms Swift's existing `#keyPath()` syntax provides a convenient way to safely *refer* to properties. Unfortunately, once validated, the expression becomes a `String` which has a number of important limitations:
+>
+> * Loss of type information (requiring awkward `Any` APIs)
+> * Unnecessarily slow to parse
+> * Only applicable to `NSObjects`
+> * Limited to Darwin platforms
+>
+> **Use/Mention Distinctions**<br/>
+> While methods can be referred to without invoking them (`let x = foo.bar` instead of  `let x = foo.bar()`), this is not currently possible for properties and subscripts. Making indirect references to a properties' concrete types also lets us expose metadata about the property, and in the future additional behaviors.
+>
+> **More Expressive KeyPaths**<br/>
+> We would also like to support being able to use _Key Paths_ to access into collections, which is not currently possible.
+
+The proposal was very well-received *except* that reviewers felt that the `#keyPath` syntax was far too heavy for this new language construct, and preferred the lighter-weight syntax of the pre-review drafts.
+
+> The heavyweight `#keyPath` syntax was requested by the core team after reviewing earlier drafts, which used a far lighter syntax:
+
+{% highlight swift %}
+// (Rejected) syntax from pre-review drafts
+let firstFriendsNameKeyPath = Person.friends[0].name
+print(luke[keyPath: .friends[0].name])
+{% endhighlight %}
+
+>
+> The core team’s specific concern was that these key path expressions (e.g., `Person.friends[0].name`) don’t make it sufficiently clear that the actual property accesses are being delayed, and that the contextual cues (“Person." vs. “luke.”) are insufficient to disambiguate for the human reader. Hence, the request for a different (more explicit) syntax.
+>
+> Reviewers rightly point out that it is natural for key-paths to use the same syntax as unapplied instance method references, e.g., `Person.someInstanceMethod` produces a value of some function type with the `Self` type curried, e.g., `(Person) -> (param-types) -> result-type`. The core team agrees with this sentiment. The core team also felt that Swift’s existing unapplied method references suffer from the same clarity problems as the initial key-path syntax, i.e., that it isn’t sufficiently clear that the actual application of `self` is being delayed.
+>
+> [Continue reading...](https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000342.html)
+
 ### Rejected proposals
 
 [SE-0159](https://github.com/apple/swift-evolution/blob/master/proposals/0159-fix-private-access-levels.md): *Fix Private Access Levels* was [rejected](https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000337.html).
@@ -57,31 +94,34 @@ Speaking of JP Simard, he released [SourceKitten 0.17.1](https://github.com/jpsi
 >
 > Swift-evolution thread: [Normalize Enum Case Representation (rev. 2)](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170306/033626.html)
 
-[SE-0161](https://github.com/apple/swift-evolution/blob/master/proposals/0161-key-paths.md): *Smart KeyPaths: Better Key-Value Coding for Swift* by David Smith, Michael LeHew, and Joe Groff is [under review](https://lists.swift.org/pipermail/swift-evolution-announce/2017-March/000334.html).
-
-> We propose a family of concrete _Key Path_ types that represent uninvoked references to properties that can be composed to form paths through many values and directly get/set their underlying values.
->
-> **We Can Do Better than String**<br/>
-> On Darwin platforms Swift's existing `#keyPath()` syntax provides a convenient way to safely *refer* to properties. Unfortunately, once validated, the expression becomes a `String` which has a number of important limitations:
->
-> * Loss of type information (requiring awkward `Any` APIs)
-> * Unnecessarily slow to parse
-> * Only applicable to `NSObjects`
-> * Limited to Darwin platforms
->
-> **Use/Mention Distinctions**<br/>
-> While methods can be referred to without invoking them (`let x = foo.bar` instead of  `let x = foo.bar()`), this is not currently possible for properties and subscripts. Making indirect references to a properties' concrete types also lets us expose metadata about the property, and in the future additional behaviors.
->
-> **More Expressive KeyPaths**<br/>
-> We would also like to support being able to use _Key Paths_ to access into collections, which is not currently possible.
-
-[SE-0162](https://github.com/apple/swift-evolution/blob/master/proposals/0162-package-manager-custom-target-layouts.md): *Package Manager Custom Target Layouts* by Ankit Aggarwal is [under review](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20170403/034997.html).
+[SE-0162](https://github.com/apple/swift-evolution/blob/master/proposals/0162-package-manager-custom-target-layouts.md): *Package Manager Custom Target Layouts* by Ankit Aggarwal is [under review](https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000339.html).
 
 > This proposal enhances the `Package.swift` manifest APIs to support custom target layouts, and removes a convention which allowed omission of targets from the manifest.
 >
 > The Package Manager uses a convention system to infer targets structure from disk layout. This works well for most packages, which can easily adopt the conventions, and frees users from needing to update their `Package.swift` file every time they add or remove sources. Adopting the conventions is more difficult for some packages, however – especially existing C libraries or large projects, which would be difficult to reorganize. We intend to give users a way to make such projects into packages without needing to conform to our conventions.
 >
 > The current convention rules make it very convenient to add new targets and source files by inferring them automatically from disk, but they also can be confusing, overly-implicit, and difficult to debug; for example, if the user does not follow the conventions correctly which determine their targets, they may wind up with targets they don't expect, or not having targets they did expect, and either way their clients can't easily see which targets are available by looking at the `Package.swift` manifest. We want to retain convenience where it really matters, such as easy addition of new source files, but require explicit declarations where being explicit adds significant value. We also want to make sure that the implicit conventions we keep are straightforward and easy to remember.
+
+[SE-0163](https://github.com/apple/swift-evolution/blob/master/proposals/0163-string-revision-1.md): *String Revision: Collection Conformance, C Interop, Transcoding* by Ben Cohen and Dave Abrahams is [under review](https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000340.html).
+
+> This proposal is to implement a subset of the changes from the [Swift 4 String Manifesto](https://github.com/apple/swift/blob/master/docs/StringManifesto.md).
+>
+> Specifically:
+>
+> Make `String` conform to `BidirectionalCollection`
+> Make `String` conform to `RangeReplaceableCollection`
+> Create a `Substring` type for `String.SubSequence`
+> Create a `Unicode` protocol to allow for generic operations over both types.
+> Consolidate on a concise set of C interop methods.
+> Revise the transcoding infrastructure.
+>
+> Other existing aspects of `String` remain unchanged for the purposes of this proposal.
+
+[SE-0164](https://github.com/apple/swift-evolution/blob/master/proposals/0164-remove-final-support-in-protocol-extensions.md): *Remove final support in protocol extensions* by Brian King is [under review](https://lists.swift.org/pipermail/swift-evolution-announce/2017-April/000341.html).
+
+> This proposal disallows the `final` keyword when declaring functions in protocol extensions.
+>
+> In the current version of Swift, the `final` keyword does not modify dispatch behavior in any way, and it does not generate an error message. This keyword has no use in Swift's current protocol model. Functions in protocol extensions cannot be overridden and will always use direct dispatch.
 
 ### Mailing lists
 


### PR DESCRIPTION
As SE-0161 was under review and has now (already) been returned for another round of review, I've put it under "Returned proposals" as a whole.