### PR TITLE
Name drafts so they get picked up by Jekyll

### DIFF
--- a/new_draft.sh
+++ b/new_draft.sh
@@ -22,10 +22,9 @@ if [[ ! ($3 =~ ^[A-Za-z]+$) ]]; then
     exit 1
 fi
 
-ISSUE="_drafts/$1-issue-$2.md"
+ISSUE="_drafts/draft-$1-issue-$2.md"
 
 mkdir -p "_drafts"
-touch $ISSUE
 
 echo "---
 layout: post


### PR DESCRIPTION
I'm using `jekyll serve --drafts` to preview the draft as I work on it, but that needs an undated file.

Updating the script here to put "draft" in front of the date. I'm pretty sure the publication step is manual but just in case there's a secret script somewhere, this does introduce an extra rename instead of just moving the file into `_posts`.

Also, you can just echo + redirect into the file; no need to `touch` it first.