### PR TITLE
[DO NOT MERGE] Add author's Twitter usernames to feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -34,6 +34,7 @@ layout: null
 
       <author>
          <name>{{ site.data.authors[post.author].name }}</name>
+         <twitter>@{{ site.data.authors[post.author].twitter }}</twitter>
       </author>
 
       <content type="html">{{ post.content | xml_escape }}</content>


### PR DESCRIPTION
In preparation of https://github.com/SwiftWeekly/swiftweekly.github.io/issues/68#issuecomment-302864455.

Not sure if we should include the `@` prefix directly in the `feed.xml`; how do we handle this elsewhere?