### PR TITLE
fix [#176] new social icons are not centered on firefox

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -209,6 +209,10 @@ footer a, footer a:visited,
    -webkit-padding-start: 0px !important;
    -webkit-margin-before: 0px !important;
    -webkit-margin-after: 0px !important;
+
+   -moz-padding-start: 0px !important;
+   -moz-margin-before: 0px !important;
+   -moz-margin-after: 0px !important;
 }
 
 .social ul li {

--- a/css/style.css
+++ b/css/style.css
@@ -211,8 +211,6 @@ footer a, footer a:visited,
    -webkit-margin-after: 0px !important;
 
    -moz-padding-start: 0px !important;
-   -moz-margin-before: 0px !important;
-   -moz-margin-after: 0px !important;
 }
 
 .social ul li {


### PR DESCRIPTION
 -webkit-padding-start: 0px !important; overrides padding for webkit, it's needed to add the same for firebox. 
#176 