### PR TITLE
Remove new encoders

### DIFF
--- a/_posts/2017-10-12-issue-91.md
+++ b/_posts/2017-10-12-issue-91.md
@@ -4,7 +4,7 @@ title: ! 'Issue #91'
 author: btb
 ---
 
-Wow, it's been quite the week! There has been a lot going on this week, and quite a few swift-evolution proposals have landed. And not the smallest ones either: Automatic `Equatable` and `Hashable` conformance, new encoders and more. Swift 4.1 is shaping up to be a great release that will make our lives even easier. 🏎💨
+Wow, it's been quite the week! There has been a lot going on this week, and quite a few swift-evolution proposals have landed. And not the smallest ones either: what about Automatic `Equatable` and `Hashable` conformance for example? Swift 4.1 is shaping up to be a great release that will make our lives even easier. 🏎💨
 
 <!--excerpt-->
 


### PR DESCRIPTION
I swear I saw a PR for this and added it to the brief, but apparently not - and I also can't find it in `apple/swift`. Am I going crazy?