### PR TITLE
Fix error regarding print performance in Issue 101

### DIFF
--- a/_posts/2018-01-25-issue-101.md
+++ b/_posts/2018-01-25-issue-101.md
@@ -45,7 +45,7 @@ Pavel Yaskevich [opened](https://github.com/apple/swift/pull/13986) a pull reque
 
 Slava Pestov [merged](https://github.com/apple/swift/pull/13573) a pull request that enables API resilience in the Standard Library. He's been working on it for [two and a half years](https://twitter.com/slava_pestov/status/953897806040674304) (!). It was one of the [three](https://github.com/apple/swift-evolution#primary-focus-abi-stability) main goals to achieve ABI stability.
 
-Chris Lattner [merged](https://github.com/apple/swift/pull/14076) a pull request that improves `print` performance in Playgrounds - after reading a [blog post](https://oleb.net/blog/2016/09/playground-print-hook/) by Ole Begemann from September 2016. 😱
+Chris Lattner [merged](https://github.com/apple/swift/pull/14076) a pull request that improves `print` performance - after reading a [blog post](https://oleb.net/blog/2016/09/playground-print-hook/) by Ole Begemann from September 2016. 😱
 
 ### Returned proposals
 


### PR DESCRIPTION
If I understand it correctly, `print` performance was suboptimal _everywhere but_ in playgrounds because the `print` function never used the fast path. Chris Lattner’s patch fixes this for non-playground environments.

PS: Thanks for the link!