### PR TITLE
Add a GitHub issue generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ You should have a good understanding of how [Jekyll](http://jekyllrb.com) and [G
 Example:
 
 ```bash
-# usage: ./new_draft.sh <DATE (yyyy-MM-dd)> <ISSUE #> <AUTHOR>
+# usage: ./new_draft.sh <DATE (YYYY-MM-dd)> <ISSUE #> <AUTHOR>
 
 $ ./new_draft.sh 2016-04-21 19 jsq  
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,9 @@ $ ./new_draft.sh 2016-04-21 19 jsq
 Example:
 
 ```bash
-$ export SWIFTWEEKLY_TOKEN=<GitHub access token with `public_repo` scope>
+# usage: export SWIFTWEEKLY_TOKEN=<GitHub access token with `public_repo` scope>
+
+$ export SWIFTWEEKLY_TOKEN=access_token
 
 # usage: ruby ./github_issue_generator.rb --number=<ISSUE #> --date=<DATE (MMMM dd, YYYY)>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,22 @@ $ ./new_draft.sh 2016-04-21 19 jsq
 # creates _drafts/2016-04-21-issue-19.md 
 ```
 
+### Generating a GitHub issue
+
+Example:
+
+```bash
+$ export SWIFTWEEKLY_TOKEN=<GitHub access token with `public_repo` scope>
+
+# usage: ruby ./github_issue_generator.rb --number=<ISSUE #> --date=<DATE (MMMM dd, YYYY)>
+
+$ ruby ./github_issue_generator.rb --number=1 --date='December 6, 2015'
+
+# more options and help:
+
+$ ruby ./github_issue_generator.rb --help
+```
+
 ### Preview the site locally, with drafts
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ $ ./new_draft.sh 2016-04-21 19 jsq
 
 ### Generating a GitHub issue
 
+To generate a GitHub access token, see the [GitHub docs](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
+
 Example:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Example:
 
 $ export SWIFTWEEKLY_TOKEN=access_token
 
-# usage: ruby ./github_issue_generator.rb --number=<ISSUE #> --date=<DATE (MMMM dd, YYYY)>
+# usage: ruby ./github_issue_generator.rb --number=<ISSUE #> --date=<DATE (MMMM d, YYYY)>
 
 $ ruby ./github_issue_generator.rb --number=1 --date='December 6, 2015'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,6 @@ gem 'github-pages', '~> 172', group: :jekyll_plugins
 gem 'jekyll-sitemap'
 gem 'danger'
 gem 'danger-prose'
+gem 'claide'
+gem 'octokit'
+gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     coffee-script-source (1.11.1)
     colorator (1.1.0)
     colored2 (3.1.2)
+    colorize (0.8.1)
     commonmarker (0.17.7.1)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
@@ -260,10 +261,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  claide
+  colorize
   danger
   danger-prose
   github-pages (~> 172)
   jekyll-sitemap
+  octokit
 
 BUNDLED WITH
    1.16.1

--- a/github_issue_generator.rb
+++ b/github_issue_generator.rb
@@ -36,8 +36,6 @@ class GitHubIssueGenerator < CLAide::Command
     help! 'The --date flag is required.' unless @date
 
     help! 'The --number flag must be a valid number.' if @number.to_i == 0
-
-    help! 'The --date flag is required.' unless @date
     help! 'The --date flag is not valid. It should follow the MMMM dd, YYYY date format, for example `December 6, 2015`.' unless valid_date? @date
   end
 

--- a/github_issue_generator.rb
+++ b/github_issue_generator.rb
@@ -4,7 +4,7 @@ require 'octokit'
 require 'colorize'
 
 class GitHubIssueGenerator < CLAide::Command
-  self.description = 'Generates a GitHub issue for the specified issue number.'
+  self.description = 'Generates a GitHub issue for the specified issue number and date.'
   self.command = 'github-issue'
 
   def self.options

--- a/github_issue_generator.rb
+++ b/github_issue_generator.rb
@@ -36,7 +36,7 @@ class GitHubIssueGenerator < CLAide::Command
     help! 'The --date flag is required.' unless @date
 
     help! 'The --number flag must be a valid number.' if @number.to_i == 0
-    help! 'The --date flag is not valid. It should follow the MMMM dd, YYYY date format, for example `December 6, 2015`.' unless valid_date? @date
+    help! 'The --date flag is not valid. It should follow the MMMM dd, YYYY date format, for example `December 6, 2015`.' unless valid_date?(@date)
   end
 
   def run

--- a/github_issue_generator.rb
+++ b/github_issue_generator.rb
@@ -35,24 +35,24 @@ class GitHubIssueGenerator < CLAide::Command
     help! 'The --number flag is required.' unless @number
     help! 'The --date flag is required.' unless @date
 
-    help! 'The --number flag must be a valid number.' if @number.to_i == 0
+    help! 'The --number flag must be a valid number.' if @number.to_i.zero?
     help! 'The --date flag is not valid. It should follow the MMMM dd, YYYY date format, for example `December 6, 2015`.' unless valid_date?(@date)
   end
 
   def run
     repo = 'SwiftWeekly/swiftweekly.github.io'
     title = "[#{@number}] Issue \##{@number} - #{@date}"
-    body = <<-eos
+    body = <<-MD
 To contribute to this issue, simply leave a comment here. Please also review [our contributing guidelines](https://github.com/SwiftWeekly/swiftweekly.github.io/blob/master/CONTRIBUTING.md).
 
 The current draft for this issue in [`_drafts/`](https://github.com/SwiftWeekly/swiftweekly.github.io/tree/master/_drafts). If you want to contribute directly, feel free to [open a pull request](https://github.com/SwiftWeekly/swiftweekly.github.io/compare?expand=1).
-    eos
+    MD
 
     labels = ['full issue notes']
     labels << (@future_issue ? 'future issue' : 'current issue')
     labels << 'needs writer' if @needs_writer
 
-    octokit = Octokit::Client.new(:access_token => @token)
+    octokit = Octokit::Client.new(access_token: @token)
 
     options = {}
     options[:assignee] = octokit.user.login unless @no_writer || @needs_writer
@@ -64,12 +64,9 @@ The current draft for this issue in [`_drafts/`](https://github.com/SwiftWeekly/
   end
 
   private
+
   def valid_date?(date)
-    begin
-      Date.parse(date) != nil
-    rescue
-      false
-    end
+    !Date.parse(date).nil? rescue false
   end
 end
 

--- a/github_issue_generator.rb
+++ b/github_issue_generator.rb
@@ -1,0 +1,78 @@
+require 'claide'
+require 'date'
+require 'octokit'
+require 'colorize'
+
+class GitHubIssueGenerator < CLAide::Command
+  self.description = 'Generates a GitHub issue for the specified issue number.'
+  self.command = 'github-issue'
+
+  def self.options
+    [
+      ['--number=1', 'The issue number to generate the GitHub issue for.'],
+      ['--date=MMMM dd, YYYY', "The date of the issue's publication, for example `December 6, 2015`."],
+      ['--future-issue', 'Adds a `future issue` label and omits the `current issue` label.'],
+      ['--no-writer', "Skips adding the runner of this script as the issue's assignee. If `--needs-writer` is set, this option will be ignored."],
+      ['--needs-writer', 'Adds a `needs writer` label and does not assign the runner of this script.']
+    ].concat(super)
+  end
+
+  def initialize(argv)
+    @token = ENV['SWIFTWEEKLY_TOKEN']
+    @number = argv.option('number')
+    @date = argv.option('date')
+    @future_issue = argv.flag?('future-issue', false)
+    @no_writer = argv.flag?('writer', true) == false # false if not supplied
+    @needs_writer = argv.flag?('needs-writer', false)
+    super
+  end
+
+  def validate!
+    super
+    help! 'You must export an access token and store it in the `SWIFTWEEKLY_TOKEN` environment variable.' unless @token
+    help! 'Your access token is invalid.' unless @token.length == 40
+    help! 'The --number and --date flags are required.' unless @number || @date
+    help! 'The --number flag is required.' unless @number
+    help! 'The --date flag is required.' unless @date
+
+    help! 'The --number flag must be a valid number.' if @number.to_i == 0
+
+    help! 'The --date flag is required.' unless @date
+    help! 'The --date flag is not valid. It should follow the MMMM dd, YYYY date format, for example `December 6, 2015`.' unless valid_date? @date
+  end
+
+  def run
+    repo = 'SwiftWeekly/swiftweekly.github.io'
+    title = "[#{@number}] Issue \##{@number} - #{@date}"
+    body = <<-eos
+To contribute to this issue, simply leave a comment here. Please also review [our contributing guidelines](https://github.com/SwiftWeekly/swiftweekly.github.io/blob/master/CONTRIBUTING.md).
+
+The current draft for this issue in [`_drafts/`](https://github.com/SwiftWeekly/swiftweekly.github.io/tree/master/_drafts). If you want to contribute directly, feel free to [open a pull request](https://github.com/SwiftWeekly/swiftweekly.github.io/compare?expand=1).
+    eos
+
+    labels = ['full issue notes']
+    labels << (@future_issue ? 'future issue' : 'current issue')
+    labels << 'needs writer' if @needs_writer
+
+    octokit = Octokit::Client.new(:access_token => @token)
+
+    options = {}
+    options[:assignee] = octokit.user.login unless @no_writer || @needs_writer
+    options[:labels] = labels.join(',')
+
+    issue = octokit.create_issue(repo, title, body, options)
+    puts "Issue succesfully created over at #{issue.html_url}.".green
+    puts 'You can press command and double-click the URL to open it in your browser.'
+  end
+
+  private
+  def valid_date?(date)
+    begin
+      Date.parse(date) != nil
+    rescue
+      false
+    end
+  end
+end
+
+GitHubIssueGenerator.run(ARGV)

--- a/github_issue_generator.rb
+++ b/github_issue_generator.rb
@@ -10,7 +10,7 @@ class GitHubIssueGenerator < CLAide::Command
   def self.options
     [
       ['--number=1', 'The issue number to generate the GitHub issue for.'],
-      ['--date=MMMM dd, YYYY', "The date of the issue's publication, for example `December 6, 2015`."],
+      ['--date=MMMM d, YYYY', "The date of the issue's publication, for example `December 6, 2015`."],
       ['--future-issue', 'Adds a `future issue` label and omits the `current issue` label.'],
       ['--no-writer', "Skips adding the runner of this script as the issue's assignee. If `--needs-writer` is set, this option will be ignored."],
       ['--needs-writer', 'Adds a `needs writer` label and does not assign the runner of this script.']
@@ -36,7 +36,7 @@ class GitHubIssueGenerator < CLAide::Command
     help! 'The --date flag is required.' unless @date
 
     help! 'The --number flag must be a valid number.' if @number.to_i.zero?
-    help! 'The --date flag is not valid. It should follow the MMMM dd, YYYY date format, for example `December 6, 2015`.' unless valid_date?(@date)
+    help! 'The --date flag is not valid. It should follow the MMMM d, YYYY date format, for example `December 6, 2015`.' unless valid_date?(@date)
   end
 
   def run

--- a/github_issue_generator.rb
+++ b/github_issue_generator.rb
@@ -54,9 +54,8 @@ The current draft for this issue in [`_drafts/`](https://github.com/SwiftWeekly/
 
     octokit = Octokit::Client.new(access_token: @token)
 
-    options = {}
+    options = { labels: labels.join(',') }
     options[:assignee] = octokit.user.login unless @no_writer || @needs_writer
-    options[:labels] = labels.join(',')
 
     issue = octokit.create_issue(repo, title, body, options)
     puts "Issue succesfully created over at #{issue.html_url}.".green


### PR DESCRIPTION
This generates the GitHub issue for a specified issue and date:

```
$ ruby github_issue_generator.rb --number=1 --date='March 5, 2018' --future-issue
Issue succesfully created over at https://github.com/BasThomas/test/issues/1.
You can press command and double-click the URL to open it in your browser.
```

Where `BasThomas/test` would obviously be `SwiftWeekly/swiftweekly.github.io`.