### PR TITLE
Add missing link to SwiftWasm forum post to issue 159

### DIFF
--- a/_drafts/2020-05-07-issue-159.md
+++ b/_drafts/2020-05-07-issue-159.md
@@ -73,7 +73,7 @@ In [episode 71](https://swiftbysundell.com/podcast/71/) of the Swift by Sundell 
 
 > This proposal adds an attribute to allow Swift enumerations to opt-in to an extensible behaviour. This reconciles a feature mismatch between resilient and non-resilient dialects of Swift, and makes Swift enumerations vastly more useful in the public API of non-resilient Swift libraries.
 
-[Yuta Saito](https://github.com/kateinoigakukun/) created a cool [demo](https://github.com/kateinoigakukun/life-game-with-swiftwasm) using [Swift support for WebAssembly](https://swiftwasm.org/). 
+[Yuta Saito](https://github.com/kateinoigakukun/) [created](https://forums.swift.org/t/wasm-support/16087/26) a cool [demo](https://github.com/kateinoigakukun/life-game-with-swiftwasm) using [Swift support for WebAssembly](https://swiftwasm.org/). 
 
 > Overall, I think it's in the state now where any help from the community would be greatly appreciated. Everyone can now [install the SwiftWasm locally with swiftenv](https://swiftwasm.github.io/swiftwasm-book/GettingStarted.html) and check if their package works. I hope to get [a GitHub action with the toolchain preinstalled](https://github.com/swiftwasm/swiftwasm-action) working ASAP so that people can start adding this to their CI.
 


### PR DESCRIPTION
Only link to the demo and Yuta's profile were previously present. Sorry for nitpicking, the quote looks a bit weird without any context or link to the original post 🙂