### PR TITLE
Correct issue #160 stating that Swift 5.3 was released

### DIFF
--- a/_posts/2020-05-21-issue-160.md
+++ b/_posts/2020-05-21-issue-160.md
@@ -33,7 +33,7 @@ Anyway... there's also news!
 
 ### News and community
 
-Swift 5.3 [was released](https://forums.swift.org/t/whats-new-in-swift-5-3/36508),
+Swift 5.3 [is going to be released soon](https://forums.swift.org/t/whats-new-in-swift-5-3/36508),
 and Larry provided a great overview of what's included.
 
 [Tim Condon](https://twitter.com/0xTim) wrote [an article](https://www.timc.dev/posts/future-of-server-side-swift) 


### PR DESCRIPTION
Swift 5.3 is not released yet.