### PR TITLE
Avoid running Danger for PRs coming from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: bundle exec jekyll build
 
       - name: danger
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
         run: bundle exec danger

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
         run: bundle exec jekyll build
 
       - name: danger
+        # The API token required for Danger to post comments is not available in fork PRs,
+        # thus disabling Danger for such PRs. See this post for more details:
+        # https://github.community/t/make-secrets-available-to-builds-of-forks/16166
         if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}


### PR DESCRIPTION
Danger step always fails as `DANGER_GITHUB_API_TOKEN` is not available for such PRs.