### PR TITLE
Copy edits: Issue 175

### DIFF
--- a/_drafts/2020-12-17-issue-175.md
+++ b/_drafts/2020-12-17-issue-175.md
@@ -9,13 +9,15 @@ sponsor:
     displaylink: https://swiftpackageindex.com/
 ---
 
-Before we head into the holiday period, we have great news about `async/await`.  Proposal adding this functionality is [under a review](https://forums.swift.org/t/se-0296-async-await/42605). Use this opportunity to express your opinion.
+Before heading into the holiday period, we have some great news about `async/await`.  The proposal adding this functionality is [under review](https://forums.swift.org/t/se-0296-async-await/42605). Use this opportunity to express your opinion.
 
 We have some news from the Swift Server Workgroup. Three new people have [joined](https://forums.swift.org/t/december-15th-2020-special-update/42865) to help support future efforts.
 
-We are ending this year with a notable initiative - [Diversity in Swift](https://swift.org/blog/diversity-in-swift/). The Diversity in Swift workgroup will use the [Community Showcase](https://forums.swift.org/c/community-showcase) to brainstorm ideas and topics for these community-focused blog posts. The [first community-focused blog post](https://swift.org/blog/accessibility-and-inclusion) is live now, and it curates helpful and moving resources about accessibility and inclusion in Swift from awesome developers within our community.
+We end this year with a notable and very welcome initiative - [Diversity in Swift](https://swift.org/blog/diversity-in-swift/). The Diversity in Swift workgroup will use the [Community Showcase](https://forums.swift.org/c/community-showcase) to brainstorm ideas and topics for these community-focused blog posts. The [first post](https://swift.org/blog/accessibility-and-inclusion) curates helpful resources for accessibility and inclusion in Swift, all made by awesome developers from our community.
 
-This post is the last issue of this year! We are taking a small break and will be back in early January. As a little reminder, we are looking for sponsors to cover our email marketing platform.
+This brief is the last issue of the year. We are taking a small festive break and will be back in early January.
+
+Evoking the spirit of philanthropy, if you'd like to support the Weekly Brief when we return, please [get in touch](mailto:fassko@gmail.com).
 
 Wishing you the happiest of holidays and a fantastic New Year!
 

--- a/_drafts/2020-12-17-issue-175.md
+++ b/_drafts/2020-12-17-issue-175.md
@@ -5,7 +5,7 @@ author: fassko
 sponsor:
     link: https://swiftpackageindex.com/
     heading:  Swift Package Index
-    body: This week’s issue is supported again by Dave Verwer who co-created the Swift Package Index, and publishes iOS Dev Weekly every Friday. He’s been a big advocate for the Weekly Brief since it started, and is supporting it because he wants to see it continue! It’s that simple.
+    body: This week’s issue is supported by Dave Verwer who co-created the Swift Package Index, and publishes iOS Dev Weekly every Friday. He’s been a big advocate for the Weekly Brief since it started, and is supporting us because he wants to see it continue! It’s that simple.
     displaylink: https://swiftpackageindex.com/
 ---
 

--- a/_drafts/2020-12-17-issue-175.md
+++ b/_drafts/2020-12-17-issue-175.md
@@ -9,7 +9,7 @@ sponsor:
     displaylink: https://swiftpackageindex.com/
 ---
 
-Before heading into the holiday period, we have some great news about `async/await`.  The proposal adding this functionality is [under review](https://forums.swift.org/t/se-0296-async-await/42605). Use this opportunity to express your opinion.
+Before heading into the holiday period, we have some great news about `async/await`. The proposal adding this functionality is [under review](https://forums.swift.org/t/se-0296-async-await/42605). It's a good opportunity to express your opinion.
 
 We have some news from the Swift Server Workgroup. Three new people have [joined](https://forums.swift.org/t/december-15th-2020-special-update/42865) to help support future efforts.
 
@@ -17,9 +17,9 @@ We end this year with a notable and very welcome initiative - [Diversity in Swif
 
 This brief is the last issue of the year. We are taking a small festive break and will be back in early January.
 
-Evoking the spirit of philanthropy, if you'd like to support the Weekly Brief when we return, please [get in touch](mailto:fassko@gmail.com).
+Evoking the spirit of philanthropy, if you'd like to sponsor the Weekly Brief when we return, please [get in touch](mailto:fassko@gmail.com).
 
-Wishing you the happiest of holidays and a fantastic New Year!
+Wishing you the happiest of holidays and a fantastic New Year! 🍷
 
 <!--excerpt-->
 

--- a/_drafts/2020-12-17-issue-175.md
+++ b/_drafts/2020-12-17-issue-175.md
@@ -35,7 +35,7 @@ In the latest episode of Swift Unwrapped, [Jesse](https://twitter.com/jesse_squi
 
 [Eneko Alonso](https://twitter.com/eneko) wrote [a blog post](https://www.enekoalonso.com/2020/12/06/getting-started-with-async-await-in-swift.html) explaining how to get started with `async/await` in Swift.
 
-[Holly Borla](https://forums.swift.org/u/hborla) wrote [a blog post](https://swift.org/blog/accessibility-and-inclusion/) that showcases a few resources about accessibility and inclusion created by developers across our community.
+[Holly Borla](https://forums.swift.org/u/hborla) wrote [a blog post](https://swift.org/blog/accessibility-and-inclusion/) that showcases resources about accessibility and inclusion created by developers across our community.
 
 [Ted Kremenek](https://twitter.com/tkremenek) announced a new initiative for the Swift project called [Diversity in Swift](https://swift.org/blog/diversity-in-swift/).
 
@@ -45,13 +45,13 @@ In the latest episode of Swift Unwrapped, [Jesse](https://twitter.com/jesse_squi
 
 [Boris Bügling](https://github.com/neonichu) opened [a pull request](https://github.com/apple/swift-package-manager/pull/3120) to add a deprecation warning for the presence of version-specific manifests.
 
-[Rintaro Ishizaki](https://github.com/rintaro) merged [a pull request](https://github.com/apple/swift/pull/35070) that fixes the problem of The `async` was being incorrectly consumed in `parseType` and as a result.
+[Rintaro Ishizaki](https://github.com/rintaro) merged [a pull request](https://github.com/apple/swift/pull/35070) that fixes a problem where `async` was being incorrectly consumed in `parseType`.
 
 ### Accepted proposals
 
 [SE-0291](https://github.com/apple/swift-evolution/blob/main/proposals/0291-package-collections.md): *Package Collections* was [accepted with modifications](https://forums.swift.org/t/accepted-with-modifications-se-0291-package-collections/42622).
 
-> The feedback from the [pitch](https://forums.swift.org/t/package-feeds/) and [first review](https://forums.swift.org/t/se-0291-package-collections/) helped ensure Package Collections are useful and put the Swift packages ecosystem on the right path. During the [first review](https://forums.swift.org/t/se-0291-package-collections/), several community members requested to learn more about the Package Collection data format and the proposal was amended to include this information. The feedback from the [2nd review 8](https://forums.swift.org/t/se-0291-2nd-review-package-collections/42369) was generally positive and the proposal has been accepted with one minor revision: The spelling for the command should be singular (`swift package-collection`) instead of plural (`swift package-collections`).
+> The feedback from the [pitch](https://forums.swift.org/t/package-feeds/) and [first review](https://forums.swift.org/t/se-0291-package-collections/) helped ensure Package Collections are useful and put the Swift packages ecosystem on the right path. During the [first review](https://forums.swift.org/t/se-0291-package-collections/), several community members requested to learn more about the Package Collection data format and the proposal was amended to include this information. The feedback from the [2nd review](https://forums.swift.org/t/se-0291-2nd-review-package-collections/42369) was generally positive and the proposal has been accepted with one minor revision: The spelling for the command should be singular (`swift package-collection`) instead of plural (`swift package-collections`).
 
 [SE-0294](https://github.com/apple/swift-evolution/blob/main/proposals/0294-package-executable-targets.md): *Declaring executable targets in Package Manifests Evolution Announcements* was [accepted with modifications](https://forums.swift.org/t/accepted-with-modifications-se-0294-declaring-executable-targets-in-package-manifests/42859).
 
@@ -75,7 +75,7 @@ In the latest episode of Swift Unwrapped, [Jesse](https://twitter.com/jesse_squi
 
 [SE-0297](https://github.com/apple/swift-evolution/blob/main/proposals/0297-concurrency-objc.md): *Concurrency Interoperability with Objective-C* is [under a review](https://forums.swift.org/t/se-0297-concurrency-interoperability-with-objective-c/42702).
 
-> Swift's concurrency feature involves asynchronous functions and actors. While Objective-C does not have corresponding language features, asynchronous APIs are common in Objective-C, expressed manually through the use of completion handlers. This proposal provides bridging between Swift's concurrency features (e.g., `async` functions) and the convention-based expression of asynchronous functions in Objective-C. It is intended to allow the wealth of existing asynchronous Objective-C APIs to be immediately usable with Swift's concurrency model.
+> Swift's concurrency feature involves asynchronous functions and actors. While Objective-C does not have corresponding language features, asynchronous APIs are common in Objective-C, expressed manually through the use of completion handlers. This proposal provides bridging between Swift's concurrency features (for example, `async` functions) and the convention-based expression of asynchronous functions in Objective-C. It is intended to allow the wealth of existing asynchronous Objective-C APIs to be immediately usable with Swift's concurrency model.
 
 ### Swift Forums
 
@@ -91,14 +91,14 @@ In the latest episode of Swift Unwrapped, [Jesse](https://twitter.com/jesse_squi
 
 > This is not dependent on the specifics of any of the proposals under discussion, but I wanted to explore a little bit what the introduction of async/await might mean for the way we program in the long term. I have just two related concerns at this point. I hope the proposers have considered these questions and have some answers, but I'd be interested in anyone's thoughts.
 
-[Doug Gregor](https://twitter.com/dgregor79) [informed](https://forums.swift.org/t/pitch-2-concurrency-interoperability-with-objective-c/42627) about updated pitch for [Concurrency Interoperability with Objective-C](https://github.com/DougGregor/swift-evolution/blob/concurrency-objc/proposals/NNNN-concurrency-objc.md).
+[Doug Gregor](https://twitter.com/dgregor79) [informed us](https://forums.swift.org/t/pitch-2-concurrency-interoperability-with-objective-c/42627) about an updated pitch for [Concurrency Interoperability with Objective-C](https://github.com/DougGregor/swift-evolution/blob/concurrency-objc/proposals/NNNN-concurrency-objc.md).
 
 > The first [pitch thread](https://forums.swift.org/t/concurrency-interoperability-with-objective-c/41616) provided a bit of feedback, which I've incorporated into this second pitch. The specific changes:
 
 > * Removed mention of asynchronous handlers, which will be in a separate proposal.
 > * Introduced the `swift_async_error` Clang attribute to separate out "throwing" behavior from the `swift_async` attribute.
 > * Added support for "Swift private" to the `swift_async` attribute.
-> * Tuned the naming heuristics based on feedback to add (e.g) `reply` , `replyTo` , `completionBlock` , and variants.
+> * Tuned the naming heuristics based on feedback to add (for example) `reply` , `replyTo` , `completionBlock` , and variants.
 > * For the rare case where we match a parameter suffix, append the text prior to the suffix to the base name.
 > * Replaced the `-generateCGImagesAsynchronouslyForTimes:completionHandler:` example with one from PassKit.
 > * Added a "Future Directions" section about `NSProgress` .
@@ -107,7 +107,7 @@ In the latest episode of Swift Unwrapped, [Jesse](https://twitter.com/jesse_squi
 
 > It's not that requiring a `try` label is always a mistake, I argued—in fact, in _some_ cases being forced to acknowledge a possible throw could be extremely helpful in reasoning about code—it's just that there are so many cases where it wasn't helpful.
 
-[George Barnett](https://twitter.com/glbrntt) asked couple of questions about source location in literals and result builders.
+[George Barnett](https://twitter.com/glbrntt) asked a couple of questions about source location in literals and result builders.
 
 > One issue I've come across recently is the fact that you cannot access the source location of the literal triggering a call to `ExpressibleByFooLiteral`, as `init(fooLiteral value: Foo, file: StaticString = #file)` would fail to fulfill the protocol requirement. There was [a pitch](https://forums.swift.org/t/pitch-allow-functions-with-default-arguments-to-fulfill-protocols/9186/15) quite some time ago to allow functions with default arguments to satisfy protocol requirements, but not much seems to have happened as a result. [Result builders](https://github.com/apple/swift-evolution/blob/main/proposals/0289-result-builders.md) might have a similar problem, as it seems one cannot write `static func buildExpression(..., file: StaticString = #file)`, though since this particular method participates on overload resolution it may just work.
 
@@ -122,11 +122,11 @@ Swift on the Server Workgroup meeting notes:
 
 [Konrad `ktoso` Malawski](https://forums.swift.org/u/ktoso) pitched [an idea](https://forums.swift.org/t/pitch-task-local-values/42829) introducing task local values to the [Swift's concurrency model ](https://forums.swift.org/t/swift-concurrency-roadmap/41611).
 
-> Task local values provide, a much needed, missing piece in the [Task 8](https://github.com/apple/swift/blob/main/stdlib/public/Concurrency/Task.swift) infrastructure puzzle. It enables instrumentation, profiling and tracing tool authors to build truly great _contextualized_ experiences for debugging, profiling and tracing codebases using asynchronous functions and actors.
+> Task local values provide a much needed missing piece in the [Task](https://github.com/apple/swift/blob/main/stdlib/public/Concurrency/Task.swift) infrastructure puzzle. It enables instrumentation, profiling and tracing tool authors to build truly great _contextualized_ experiences for debugging, profiling and tracing codebases using asynchronous functions and actors.
 >
-> At the same time this proposal avoids pitfalls of similar APIs thanks to embracing Swift's [Structured Concurrency 4](https://forums.swift.org/t/concurrency-structured-concurrency/41622) approach.
+> At the same time this proposal avoids pitfalls of similar APIs thanks to embracing Swift's [Structured Concurrency](https://forums.swift.org/t/concurrency-structured-concurrency/41622) approach.
 >
-> [Please refer to the complete & up-to-date pitch document here](https://github.com/ktoso/swift-evolution/blob/wip-tasklocals/proposals/nnnn-task-locals.md#alternative-api-considered)
+> Please refer to [the complete and up-to-date pitch document](https://github.com/ktoso/swift-evolution/blob/wip-tasklocals/proposals/nnnn-task-locals.md#alternative-api-considered)
 
 ### Finally
 

--- a/_drafts/2020-12-17-issue-175.md
+++ b/_drafts/2020-12-17-issue-175.md
@@ -63,7 +63,7 @@ In the latest episode of Swift Unwrapped, [Jesse](https://twitter.com/jesse_squi
 
 [SE-0293](https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md) has been [returned for revision](https://forums.swift.org/t/returned-for-revision-se-0293-extend-property-wrappers-to-function-and-closure-parameters/42953).
 
-> Most of the discussion in the feedback thread centered around a central question of "what is the type of a function that has a property wrapper parameter?".  The proposal describes a model where the wrapper is part of the exposed type (e.g. `(Binding<Item>)->Void`), but many data points in the thread argued for a model where the exposed type of a function is the unwrapped type (e.g. `(Item)->Void`).
+> Most of the discussion in the feedback thread centered around a central question of "what is the type of a function that has a property wrapper parameter?".  The proposal describes a model where the wrapper is part of the exposed type (for example `(Binding<Item>)->Void`), but many data points in the thread argued for a model where the exposed type of a function is the unwrapped type (for example `(Item)->Void`).
 
 ### Proposals in review
 


### PR DESCRIPTION
Usual edits for language, readability and flow:

- Copy edits and slight rewording for the introduction text
- Minor link list corrections

Hope that helps! 