### PR TITLE
Add a missing link to issue 179

### DIFF
--- a/_posts/2021-02-25-issue-179.md
+++ b/_posts/2021-02-25-issue-179.md
@@ -36,7 +36,7 @@ The Swift language has been included in the [Google Summer of Code](https://summ
 
 Robert Pieta shared a great [article](https://www.advancedswift.com/typealias-examples/) explaining variable, tuple, closure, and generic typealias in Swift.
 
-[Tibor Bödecs](https://twitter.com/tiborbodecs) wrote an article explaining the Swift compiler for beginners.
+[Tibor Bödecs](https://twitter.com/tiborbodecs) wrote [an article explaining the Swift compiler for beginners](https://theswiftdev.com/the-swift-compiler-for-beginners/).
 
 ### Commits and pull requests
 


### PR DESCRIPTION
"An article explaining the Swift compiler for beginners" had no link to the article itself.