### PR TITLE
Add newsletter template rendering through Jekyll.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
     faraday-net_http (1.0.1)
-    ffi (1.14.2)
+    ffi (1.15.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     git (1.8.1)
@@ -233,6 +233,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.5.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
@@ -241,6 +242,11 @@ GEM
     multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.1-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.20.0)
@@ -303,4 +309,4 @@ DEPENDENCIES
   octokit
 
 BUNDLED WITH
-   2.2.2
+   2.2.6

--- a/newsletter-template.html
+++ b/newsletter-template.html
@@ -1,0 +1,696 @@
+---
+layout: none
+title: newsletter-template
+---
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><!-- NAME: BASIC RSS --><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">{% assign post = site.posts.first %}
+    <title>{{ post.title }}</title>
+    <style type="text/css">body,#bodyTable,#bodyCell{
+            height:100% !important;
+            margin:0;
+            padding:0;
+            width:100% !important;
+        }
+        table{
+            border-collapse:collapse;
+        }
+        img,a img{
+            border:0;
+            outline:none;
+            text-decoration:none;
+        }
+        h1,h2,h3,h4,h5,h6{
+            margin:0;
+            padding:0;
+        }
+        p{
+            margin:1em 0;
+            padding:0;
+        }
+        a{
+            word-wrap:break-word;
+        }
+        .mcnPreviewText{
+            display:none !important;
+        }
+        .ReadMsgBody{
+            width:100%;
+        }
+        .ExternalClass{
+            width:100%;
+        }
+        .ExternalClass,.ExternalClass p,.ExternalClass span,.ExternalClass font,.ExternalClass td,.ExternalClass div{
+            line-height:100%;
+        }
+        table,td{
+            mso-table-lspace:0pt;
+            mso-table-rspace:0pt;
+        }
+        #outlook a{
+            padding:0;
+        }
+        img{
+            -ms-interpolation-mode:bicubic;
+        }
+        body,table,td,p,a,li,blockquote{
+            -ms-text-size-adjust:100%;
+            -webkit-text-size-adjust:100%;
+        }
+        #templatePreheader,#templateHeader,#templateBody,#templateFooter{
+            min-width:100%;
+        }
+        #bodyCell{
+            padding:20px;
+        }
+        .mcnImage,.mcnRetinaImage{
+            vertical-align:bottom;
+        }
+        .mcnTextContent img{
+            height:auto !important;
+        }
+    /*
+    @tab Page
+    @section background style
+    @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding.
+    */
+        body,#bodyTable{
+            /*@editable*/background-color:#F2F2F2;
+        }
+    /*
+    @tab Page
+    @section background style
+    @tip Set the background color and top border for your email. You may want to choose colors that match your company's branding.
+    */
+        #bodyCell{
+            /*@editable*/border-top:0;
+        }
+    /*
+    @tab Page
+    @section email border
+    @tip Set the border for your email.
+    */
+        #templateContainer{
+            /*@editable*/border:0;
+        }
+    /*
+    @tab Page
+    @section heading 1
+    @tip Set the styling for all first-level headings in your emails. These should be the largest of your headings.
+    @style heading 1
+    */
+        h1{
+            /*@editable*/color:#606060 !important;
+            display:block;
+            /*@editable*/font-family:Helvetica;
+            /*@editable*/font-size:40px;
+            /*@editable*/font-style:normal;
+            /*@editable*/font-weight:bold;
+            /*@editable*/line-height:125%;
+            /*@editable*/letter-spacing:normal;
+            margin:0;
+            /*@editable*/text-align:left;
+        }
+    /*
+    @tab Page
+    @section heading 2
+    @tip Set the styling for all second-level headings in your emails.
+    @style heading 2
+    */
+        h2{
+            /*@editable*/color:#404040 !important;
+            display:block;
+            /*@editable*/font-family:Helvetica;
+            /*@editable*/font-size:26px;
+            /*@editable*/font-style:normal;
+            /*@editable*/font-weight:bold;
+            /*@editable*/line-height:125%;
+            /*@editable*/letter-spacing:normal;
+            margin:0;
+            /*@editable*/text-align:left;
+        }
+    /*
+    @tab Page
+    @section heading 3
+    @tip Set the styling for all third-level headings in your emails.
+    @style heading 3
+    */
+        h3{
+            /*@editable*/color:#606060 !important;
+            display:block;
+            /*@editable*/font-family:Helvetica;
+            /*@editable*/font-size:26px;
+            /*@editable*/font-style:normal;
+            /*@editable*/font-weight:bold;
+            /*@editable*/line-height:125%;
+            /*@editable*/letter-spacing:normal;
+            margin:0;
+            /*@editable*/text-align:left;
+        }
+    /*
+    @tab Page
+    @section heading 4
+    @tip Set the styling for all fourth-level headings in your emails. These should be the smallest of your headings.
+    @style heading 4
+    */
+        h4{
+            /*@editable*/color:#808080 !important;
+            display:block;
+            /*@editable*/font-family:Helvetica;
+            /*@editable*/font-size:16px;
+            /*@editable*/font-style:normal;
+            /*@editable*/font-weight:bold;
+            /*@editable*/line-height:125%;
+            /*@editable*/letter-spacing:normal;
+            margin:0;
+            /*@editable*/text-align:left;
+        }
+    /*
+    @tab Preheader
+    @section preheader style
+    @tip Set the background color and borders for your email's preheader area.
+    */
+        #templatePreheader{
+            /*@editable*/background-color:#FFFFFF;
+            /*@editable*/border-top:0;
+            /*@editable*/border-bottom:0;
+        }
+    /*
+    @tab Preheader
+    @section preheader text
+    @tip Set the styling for your email's preheader text. Choose a size and color that is easy to read.
+    */
+        .preheaderContainer .mcnTextContent,.preheaderContainer .mcnTextContent p{
+            /*@editable*/color:#606060;
+            /*@editable*/font-family:Helvetica;
+            /*@editable*/font-size:11px;
+            /*@editable*/line-height:125%;
+            /*@editable*/text-align:left;
+        }
+    /*
+    @tab Preheader
+    @section preheader link
+    @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text.
+    */
+        .preheaderContainer .mcnTextContent a{
+            /*@editable*/color:#606060;
+            /*@editable*/font-weight:normal;
+            /*@editable*/text-decoration:underline;
+        }
+    /*
+    @tab Header
+    @section header style
+    @tip Set the background color and borders for your email's header area.
+    */
+        #templateHeader{
+            /*@editable*/background-color:#FFFFFF;
+            /*@editable*/border-top:0;
+            /*@editable*/border-bottom:0;
+        }
+    /*
+    @tab Header
+    @section header text
+    @tip Set the styling for your email's header text. Choose a size and color that is easy to read.
+    */
+        .headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
+            /*@editable*/color:#606060;
+            /*@editable*/font-family:Helvetica;
+            /*@editable*/font-size:30px;
+            /*@editable*/line-height:200%;
+            /*@editable*/text-align:left;
+        }
+    /*
+    @tab Header
+    @section header link
+    @tip Set the styling for your email's header links. Choose a color that helps them stand out from your text.
+    */
+        .headerContainer .mcnTextContent a{
+            /*@editable*/color:#f05138;
+            /*@editable*/font-weight:normal;
+            /*@editable*/text-decoration:underline;
+        }
+    /*
+    @tab Body
+    @section body style
+    @tip Set the background color and borders for your email's body area.
+    */
+        #templateBody{
+            /*@editable*/background-color:#FFFFFF;
+            /*@editable*/border-top:0;
+            /*@editable*/border-bottom:0;
+        }
+    /*
+    @tab Body
+    @section body text
+    @tip Set the styling for your email's body text. Choose a size and color that is easy to read.
+    */
+        .bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
+            /*@editable*/color:#606060;
+            /*@editable*/font-family:Helvetica;
+            /*@editable*/font-size:15px;
+            /*@editable*/line-height:150%;
+            /*@editable*/text-align:left;
+        }
+    /*
+    @tab Body
+    @section body link
+    @tip Set the styling for your email's body links. Choose a color that helps them stand out from your text.
+    */
+        .bodyContainer .mcnTextContent a{
+            /*@editable*/color:#f05138;
+            /*@editable*/font-weight:normal;
+            /*@editable*/text-decoration:underline;
+        }
+    /*
+    @tab Footer
+    @section footer style
+    @tip Set the background color and borders for your email's footer area.
+    */
+        #templateFooter{
+            /*@editable*/background-color:#FFFFFF;
+            /*@editable*/border-top:0;
+            /*@editable*/border-bottom:0;
+        }
+    /*
+    @tab Footer
+    @section footer text
+    @tip Set the styling for your email's footer text. Choose a size and color that is easy to read.
+    */
+        .footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
+            /*@editable*/color:#606060;
+            /*@editable*/font-family:Helvetica;
+            /*@editable*/font-size:11px;
+            /*@editable*/line-height:125%;
+            /*@editable*/text-align:left;
+        }
+    /*
+    @tab Footer
+    @section footer link
+    @tip Set the styling for your email's footer links. Choose a color that helps them stand out from your text.
+    */
+        .footerContainer .mcnTextContent a{
+            /*@editable*/color:#606060;
+            /*@editable*/font-weight:normal;
+            /*@editable*/text-decoration:underline;
+        }
+    @media only screen and (max-width: 480px){
+        body,table,td,p,a,li,blockquote{
+            -webkit-text-size-adjust:none !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        body{
+            width:100% !important;
+            min-width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        .mcnRetinaImage{
+            max-width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[id=bodyCell]{
+            padding:10px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        table[class=mcnTextContentContainer]{
+            width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        .mcnBoxedTextContentContainer{
+            max-width:100% !important;
+            min-width:100% !important;
+            width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        table[class=mcpreview-image-uploader]{
+            width:100% !important;
+            display:none !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        img[class=mcnImage]{
+            width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        table[class=mcnImageGroupContentContainer]{
+            width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=mcnImageGroupContent]{
+            padding:9px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=mcnImageGroupBlockInner]{
+            padding-bottom:0 !important;
+            padding-top:0 !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        tbody[class=mcnImageGroupBlockOuter]{
+            padding-bottom:9px !important;
+            padding-top:9px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        table[class=mcnCaptionTopContent],table[class=mcnCaptionBottomContent]{
+            width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        table[class=mcnCaptionLeftTextContentContainer],table[class=mcnCaptionRightTextContentContainer],table[class=mcnCaptionLeftImageContentContainer],table[class=mcnCaptionRightImageContentContainer],table[class=mcnImageCardLeftTextContentContainer],table[class=mcnImageCardRightTextContentContainer],.mcnImageCardLeftImageContentContainer,.mcnImageCardRightImageContentContainer{
+            width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=mcnImageCardLeftImageContent],td[class=mcnImageCardRightImageContent]{
+            padding-right:18px !important;
+            padding-left:18px !important;
+            padding-bottom:0 !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=mcnImageCardBottomImageContent]{
+            padding-bottom:9px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=mcnImageCardTopImageContent]{
+            padding-top:18px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        table[class=mcnCaptionLeftContentOuter] td[class=mcnTextContent],table[class=mcnCaptionRightContentOuter] td[class=mcnTextContent]{
+            padding-top:9px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=mcnCaptionBlockInner] table[class=mcnCaptionTopContent]:last-child td[class=mcnTextContent],.mcnImageCardTopImageContent,.mcnCaptionBottomContent:last-child .mcnCaptionBottomImageContent{
+            padding-top:18px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=mcnBoxedTextContentColumn]{
+            padding-left:18px !important;
+            padding-right:18px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=mcnTextContent]{
+            padding-right:18px !important;
+            padding-left:18px !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section template width
+    @tip Make the template fluid for portrait or landscape view adaptability. If a fluid layout doesn't work for you, set the width to 300px instead.
+    */
+        table[id=templateContainer],table[id=templatePreheader],table[id=templateHeader],table[id=templateBody],table[id=templateFooter]{
+            /*@tab Mobile Styles
+@section template width
+@tip Make the template fluid for portrait or landscape view adaptability. If a fluid layout doesn't work for you, set the width to 300px instead.*/max-width:600px !important;
+            /*@editable*/width:100% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section heading 1
+    @tip Make the first-level headings larger in size for better readability on small screens.
+    */
+        h1{
+            /*@editable*/font-size:24px !important;
+            /*@editable*/line-height:125% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section heading 2
+    @tip Make the second-level headings larger in size for better readability on small screens.
+    */
+        h2{
+            /*@editable*/font-size:20px !important;
+            /*@editable*/line-height:125% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section heading 3
+    @tip Make the third-level headings larger in size for better readability on small screens.
+    */
+        h3{
+            /*@editable*/font-size:22px !important;
+            /*@editable*/line-height:125% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section heading 4
+    @tip Make the fourth-level headings larger in size for better readability on small screens.
+    */
+        h4{
+            /*@editable*/font-size:16px !important;
+            /*@editable*/line-height:125% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section Boxed Text
+    @tip Make the boxed text larger in size for better readability on small screens. We recommend a font size of at least 16px.
+    */
+        table[class=mcnBoxedTextContentContainer] td[class=mcnTextContent],td[class=mcnBoxedTextContentContainer] td[class=mcnTextContent] p{
+            /*@editable*/font-size:18px !important;
+            /*@editable*/line-height:125% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section Preheader Visibility
+    @tip Set the visibility of the email's preheader on small screens. You can hide it to save space.
+    */
+        table[id=templatePreheader]{
+            /*@editable*/display:block !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section Preheader Text
+    @tip Make the preheader text larger in size for better readability on small screens.
+    */
+        td[class=preheaderContainer] td[class=mcnTextContent],td[class=preheaderContainer] td[class=mcnTextContent] p{
+            /*@editable*/font-size:14px !important;
+            /*@editable*/line-height:115% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section Header Text
+    @tip Make the header text larger in size for better readability on small screens.
+    */
+        td[class=headerContainer] td[class=mcnTextContent],td[class=headerContainer] td[class=mcnTextContent] p{
+            /*@editable*/font-size:18px !important;
+            /*@editable*/line-height:125% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section Body Text
+    @tip Make the body text larger in size for better readability on small screens. We recommend a font size of at least 16px.
+    */
+        td[class=bodyContainer] td[class=mcnTextContent],td[class=bodyContainer] td[class=mcnTextContent] p{
+            /*@editable*/font-size:18px !important;
+            /*@editable*/line-height:125% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+    /*
+    @tab Mobile Styles
+    @section footer text
+    @tip Make the body content text larger in size for better readability on small screens.
+    */
+        td[class=footerContainer] td[class=mcnTextContent],td[class=footerContainer] td[class=mcnTextContent] p{
+            /*@editable*/font-size:14px !important;
+            /*@editable*/line-height:115% !important;
+        }
+
+}    @media only screen and (max-width: 480px){
+        td[class=footerContainer] a[class=utilityLink]{
+            display:block !important;
+        }
+
+}
+    </style>
+</head>
+<body leftmargin="0" marginheight="0" marginwidth="0" offset="0" topmargin="0">
+<center>
+<table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" id="bodyTable" width="100%">
+    <tbody>
+        <tr>
+            <td align="center" id="bodyCell" valign="top"><!-- BEGIN TEMPLATE // -->
+            <table border="0" cellpadding="0" cellspacing="0" id="templateContainer" width="600">
+                <tbody>
+                    <tr>
+                        <td align="center" valign="top"><!-- BEGIN PREHEADER // -->
+                        <table border="0" cellpadding="0" cellspacing="0" id="templatePreheader" width="600">
+                            <tbody>
+                                <tr>
+                                    <td class="preheaderContainer" style="padding-top:9px;" valign="top">
+                                    <table border="0" cellpadding="0" cellspacing="0" class="mcnTextBlock" style="min-width:100%;" width="100%">
+                                        <tbody class="mcnTextBlockOuter">
+                                            <tr>
+                                                <td class="mcnTextBlockInner" valign="top">
+                                                <table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnTextContentContainer" width="366">
+                                                    <tbody>
+                                                        <tr>
+                                                            <td class="mcnTextContent" style="padding-top:9px; padding-left:18px; padding-bottom:9px; padding-right:0;" valign="top">&nbsp;</td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+
+                                                <table align="right" border="0" cellpadding="0" cellspacing="0" class="mcnTextContentContainer" width="197">
+                                                    <tbody>
+                                                        <tr>
+                                                            <td class="mcnTextContent" style="padding-top:9px; padding-right:18px; padding-bottom:9px; padding-left:18px;" valign="top"><a href="*|URL|*" target="_blank">View this email in your browser</a></td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- // END PREHEADER --></td>
+                    </tr>
+                    <tr>
+                        <td align="center" valign="top"><!-- BEGIN HEADER // -->
+                        <table border="0" cellpadding="0" cellspacing="0" id="templateHeader" width="600">
+                            <tbody>
+                                <tr>
+                                    <td class="headerContainer" valign="top">&nbsp;</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- // END HEADER --></td>
+                    </tr>
+                    <tr>
+                        <td align="center" valign="top"><!-- BEGIN BODY // -->
+                        <table border="0" cellpadding="0" cellspacing="0" id="templateBody" width="600">
+                            <tbody>
+                                <tr>
+                                    <td class="bodyContainer" valign="top">
+                                    <table border="0" cellpadding="0" cellspacing="0" class="mcnTextBlock" style="min-width:100%;" width="100%">
+                                        <tbody class="mcnTextBlockOuter">
+                                            <tr>
+                                                <td class="mcnTextBlockInner" valign="top">
+                                                <table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnTextContentContainer" style="min-width:100%;" width="100%">
+                                                    <tbody>
+                                                        <tr>
+                                                            <td class="mcnTextContent" style="padding-top:9px; padding-right: 18px; padding-bottom: 9px; padding-left: 18px;" valign="top">
+                                                            <h1>Swift Weekly Brief</h1>
+                                                            </td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+
+                                    <table border="0" cellpadding="0" cellspacing="0" class="mcnTextBlock" style="min-width:100%;" width="100%">
+                                        <tbody class="mcnTextBlockOuter">
+                                            <tr>
+                                                <td class="mcnTextBlockInner" valign="top">
+                                                <table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnTextContentContainer" style="min-width:100%;" width="100%">
+                                                    <tbody>
+                                                        <tr>
+                                                            <td class="mcnTextContent" style="padding-top:9px; padding-right: 18px; padding-bottom: 9px; padding-left: 18px;" valign="top">
+                                                            <h2 class="mc-toc-title"><a href="{{ site.url }}{{ post.url }}" target="_blank">{{ post.title }}</a></h2>
+                                                            <em>By {{ site.data.authors[post.author].name }}</em><br />
+                                                            {{ post.content }}<br />
+                                                            <a href="{{ site.url }}{{ post.url }}" target="_blank">Open in browser &raquo;</a></td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- // END BODY --></td>
+                    </tr>
+                    <tr>
+                        <td align="center" valign="top"><!-- BEGIN FOOTER // -->
+                        <table border="0" cellpadding="0" cellspacing="0" id="templateFooter" width="600">
+                            <tbody>
+                                <tr>
+                                    <td class="footerContainer" style="padding-bottom:9px;" valign="top">
+                                    <table border="0" cellpadding="0" cellspacing="0" class="mcnTextBlock" style="min-width:100%;" width="100%">
+                                        <tbody class="mcnTextBlockOuter">
+                                            <tr>
+                                                <td class="mcnTextBlockInner" style="padding-top:9px;" valign="top"><!--[if mso]>
+                <table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+                <tr>
+                <![endif]--><!--[if mso]>
+                <td valign="top" width="600" style="width:600px;">
+                <![endif]-->
+                                                <table align="left" border="0" cellpadding="0" cellspacing="0" class="mcnTextContentContainer" style="max-width:100%; min-width:100%;" width="100%">
+                                                    <tbody>
+                                                        <tr>
+                                                            <td class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;" valign="top">
+                                                            Newsletter hosting by <a href="https://appforce1.net/swiftweeklybrief/">AppForce1</a>.</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td class="mcnTextContent" style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;" valign="top"><em>Copyright &copy; [currentyear] Swift Weekly Brief, All rights reserved.</em><br />
+                                                            You are receiving this email because you opted in via our website.<br />
+                                                            You can <unsubscribe>unsubscribe here</unsubscribe>.</td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                                <!--[if mso]>
+                </td>
+                <![endif]--><!--[if mso]>
+                </tr>
+                </table>
+                <![endif]--></td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- // END FOOTER --></td>
+                    </tr>
+                </tbody>
+            </table>
+            <!-- // END TEMPLATE --></td>
+        </tr>
+    </tbody>
+</table>
+</center>
+</body>
+</html>
+


### PR DESCRIPTION
I transfered the Mailchimp newsletter template towards "our own" this template is fully responsive and should work well in almost all mail clients. All the seemingly random cruft with comments and all is all there with reasons.

Also, I had to update the bundled Gems to make local rendering work. Is that ok?

The resulting newsletter page, which should not be navigable from other pages is located here: `/newsletter-template/`.

The source of this page can be copied one on one as the newsletter source.

That's also why there are two seemingly strange artefacts in the source page.
- `<unsubscribe>unsubscribe here</unsubscribe>`
- `[currentyear]`

The first one renders the correct unsubscribe link. The second renders the current year.