### PR TITLE
Clean up links and summaries

### DIFF
--- a/_posts/2021-07-29-issue-190.md
+++ b/_posts/2021-07-29-issue-190.md
@@ -33,28 +33,29 @@ Great [article](https://holyswift.app/using-tuples-to-complex-sorting-operations
 
 [SE-0319](https://github.com/apple/swift-evolution/blob/main/proposals/0319-never-identifiable.md) *Never as Identifiable* was [accepted](https://forums.swift.org/t/accepted-se-0319-never-as-identifiable/50473).
 
->  The core team has accepted this proposal. Support for the added functionality was unanimous; there was some discussion about whether the proposal might be better titled "type placeholders" or "inferred types", but that would not affect the behavior of the feature within the language. Thanks to everyone who participated in the review!
+>  Feedback from the review was positive, and mostly focused on further exploration of making `Never` a true bottom type, or similar alternatives to expanding the list of protocols `Never` conforms to in a systemic manner. The core team acknowledges this is an interesting design space and encourages follow up proposals exploring it.
 
-[SE-0317](https://forums.swift.org/t/se-0317-async-let/) *Async Let* was [accepted](https://forums.swift.org/t/accepted-se-0317-async-let/50695).
+[SE-0317](https://github.com/apple/swift-evolution/blob/main/proposals/0317-async-let.md) *Async Let* was [accepted](https://forums.swift.org/t/accepted-se-0317-async-let/50695).
 
 > A significant area of feedback during the review was that of the creation of implicit suspension points when an `async let` variable is not awaited on a path that exits a scope that is not itself an awaited function. This creates an exception to the rule that suspension points are always marked with an `await`.
 >
-> After thorough discussion of the alternatives to implicit suspension points, the core team feels that language-level solutions add more complexity than is warranted to eliminate implicit suspension points.  
-The core team acknowledges that this exception may have more impact in practice than can be reasoned about without real-world use. There is an opportunity to react to real-world feedback in Swift 6 by tightening up the model around implicit awaits if it turns out that they are harmful in practice (although it is not currently the intention to do so).
+> After thorough discussion of the alternatives to implicit suspension points, the core team feels that language-level solutions add more complexity than is warranted to eliminate implicit suspension points.
+>
+> The core team acknowledges that this exception may have more impact in practice than can be reasoned about without real-world use. There is an opportunity to react to real-world feedback in Swift 6 by tightening up the model around implicit awaits if it turns out that they are harmful in practice (although it is not currently the intention to do so).
 >
 > The proposal authors have added descriptions of other solutions and their downsides to the [alternatives considered](https://github.com/apple/swift-evolution/blob/main/proposals/0317-async-let.md#requiring-an-awaiton-any-execution-path-that-waits-for-an-async-let) section of the proposal. This section also has additions covering other alternatives discussed during the review, such as the use of property wrappers for a partial library-level solution.
 
-[SE-0315](https://forums.swift.org/t/se-0315-placeholder-types/49801) *Async Let* was [accepted](https://forums.swift.org/t/accepted-se-0315-placeholder-types/50671).
+[SE-0315](https://github.com/apple/swift-evolution/blob/main/proposals/0315-placeholder-types.md) *Type placeholders* was [accepted](https://forums.swift.org/t/accepted-se-0315-placeholder-types/50671).
 
 > Support for the added functionality was unanimous; there was some discussion about whether the proposal might be better titled "type placeholders" or "inferred types", but that would not affect the behavior of the feature within the language. Thanks to everyone who participated in the review!
 
-[SE-0314](https://github.com/apple/swift-evolution/blob/main/proposals/0314-async-stream.md) *AsyncStream and AsyncThrowingStream* [second review](https://forums.swift.org/t/se-0314-second-review-asyncstream-and-asyncthrowingstream/49803) was [accepted](https://forums.swift.org/t/accepted-se-0314-asyncstream-and-asyncthrowingstream/50699).
+[SE-0314](https://github.com/apple/swift-evolution/blob/main/proposals/0314-async-stream.md) *`AsyncStream` and `AsyncThrowingStream`* [second review](https://forums.swift.org/t/se-0314-second-review-asyncstream-and-asyncthrowingstream/49803) was [accepted](https://forums.swift.org/t/accepted-se-0314-asyncstream-and-asyncthrowingstream/50699).
 
 > The proposal is **accepted**. After much discussion, Core Team has decided to retain the `AsyncStream` and `AsyncThrowingStream` names as proposed.
 
 ### Returned proposals
 
-[SE-0318](https://forums.swift.org/t/se-0318-package-creation/) has been [returned for revision](https://forums.swift.org/t/returned-for-revision-se-0318-package-creation/50474).
+[SE-0318](https://github.com/apple/swift-evolution/blob/main/proposals/0318-package-creation.md) has been [returned for revision](https://forums.swift.org/t/returned-for-revision-se-0318-package-creation/50474).
 
 > The feedback from the review highlighted further refinement that can be done to the ergonomics of the proposed solution including the templating system. For example, the proposal can make it clearer why a new command is desired compared to enhancing the existing package init command, and explore a templating system that supports for multi-template-single-repo and programatic interfaces.
 > 
@@ -64,7 +65,7 @@ The core team acknowledges that this exception may have more impact in practice 
 
 [Gutley](https://forums.swift.org/u/gutley) pitched [an idea](https://forums.swift.org/t/catching-unwanted-uses-of-on-optionset/50566) to implement a solution to catch unwanted uses of `~=` on OptionSet.
 
-[Johannes Auer](https://forums.swift.org/t/pre-pitch-asyncvalue/50590) pitched a proposal to add `AsyncValue`.
+[Johannes Auer](https://forums.swift.org/u/jmjauer/summary) pitched a [proposal](https://forums.swift.org/t/pre-pitch-asyncvalue/50590) to add `AsyncValue`.
 
 > While migrating a project to the new async features of Swift I constantly needed a mechanism for a synchronization point based of the availability of some value. As far as I can tell, currently there is nothing in the stdlib to cover this.
 >
@@ -95,6 +96,6 @@ The core team acknowledges that this exception may have more impact in practice 
 
 ### Finally
 
-* [https://twitter.com/zats/status/1419343807229960199](Carbonara.framework)
-* [https://twitter.com/jckarter/status/1418996455616835585](Dissociated types)
-* [https://twitter.com/DeepSchneider/status/1417195426877431811](Reverse-pascal-reverse-snake case)
+* [Carbonara.framework](https://twitter.com/zats/status/1419343807229960199)
+* [Dissociated types](https://twitter.com/jckarter/status/1418996455616835585)
+* [Reverse-pascal-reverse-snake case](https://twitter.com/DeepSchneider/status/1417195426877431811)


### PR DESCRIPTION
- Standardize on linking to profiles for user names.
- Standardize on linking to GitHub for SE's and forum threads for decisions.
- Fix a wrong decision summary.
- Fix inverted Markdown link syntax.